### PR TITLE
Split Consul Cluster in Two - One for Vault and One for SD & KV Services

### DIFF
--- a/admin_policy.hcl
+++ b/admin_policy.hcl
@@ -1,0 +1,47 @@
+    # Manage auth backends broadly across Vault
+    path "auth/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # List, create, update, and delete auth backends
+    path "sys/auth/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "sudo"]
+    }
+
+    # List existing policies
+    path "sys/policy"
+    {
+    capabilities = ["read"]
+    }
+
+    # Create and manage ACL policies broadly across Vault
+    path "sys/policy/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # List, create, update, and delete key/value secrets
+    path "secret/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # List, create, update, and delete key/value secrets
+    path "kv/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    }
+
+    # Manage and manage secret backends broadly across Vault.
+    path "sys/mounts/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # Read health checks
+    path "sys/health"
+    {
+    capabilities = ["read", "sudo"]
+    }

--- a/conf/consulforvault.d/consul.hcl
+++ b/conf/consulforvault.d/consul.hcl
@@ -1,0 +1,9 @@
+{
+  "ports": {
+    "http": 7500,
+    "dns": 7600,
+    "serf_lan": 7301,
+    "serf_wan": 7302,
+    "server": 7300
+  }
+}

--- a/conf/vault.d/vault.hcl
+++ b/conf/vault.d/vault.hcl
@@ -1,5 +1,5 @@
 storage "consul" {
-  address = "127.0.0.1:8500"
+  address = "127.0.0.1:7500"
   path    = "vault/"
 }
 

--- a/database_policy.hcl
+++ b/database_policy.hcl
@@ -1,0 +1,5 @@
+    # List read key/value secrets
+    path "kv/development/redispassword"
+    {
+    capabilities = ["read", "list"]
+    }

--- a/provisioner_policy.hcl
+++ b/provisioner_policy.hcl
@@ -1,0 +1,35 @@
+    # Manage auth backends broadly across Vault
+    path "auth/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # List, create, update, and delete auth backends
+    path "sys/auth/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "sudo"]
+    }
+
+    # List existing policies
+    path "sys/policy"
+    {
+    capabilities = ["read"]
+    }
+
+    # Create and manage ACL policies
+    path "sys/policy/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    }
+
+    # List, create, update, and delete key/value secrets
+    path "secret/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    }
+
+    # List, create, update, and delete key/value secrets
+    path "kv/*"
+    {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    }

--- a/scripts/install_vault.sh
+++ b/scripts/install_vault.sh
@@ -456,4 +456,5 @@ install_vault () {
 }
 
 setup_environment
+install_consul_as_backend_for_vault
 install_vault


### PR DESCRIPTION
# Why is the PR required?

### Issue:

Demonstrate how a consul cluster and be separated out into two clusters - one dedicated as a Vault Storage Backend with non standard ports and the second consul cluster used for service discovery and standard KV management.

## What does this PR do?

Creates a new Consul cluster dedicated for Vault storage backend using non-standard consul ports.

## How was this PR implemented?

![vault consul - phase 1](https://user-images.githubusercontent.com/9472095/47297619-7a535280-d60d-11e8-8804-e149170dd188.png)

- Installed a new instance of consul on non standard ports.
- Added a new dedicated Consul user.
- Created a new Vault service registration file for the Consul cluster that's supplying the service discovery features.

## How long did it take?

2 hours

