### PR TITLE
Moved Vault to it's own node

### DIFF
--- a/scripts/install_vault.sh
+++ b/scripts/install_vault.sh
@@ -460,8 +460,8 @@ install_vault () {
     # verify it's either the TRAVIS server or the Vault server
     if [[ "${HOSTNAME}" =~ "vault" ]] || [ "${TRAVIS}" == "true" ]; then
         #lets kill past instance
-        create_consulforvault_service_user
-        install_consul_as_backend_for_vault
+        #create_consulforvault_service_user
+        #install_consul_as_backend_for_vault
         sudo killall vault &>/dev/null
 
         #lets delete old consul storage


### PR DESCRIPTION
# Why is the PR required?

Implemented the following setup in Vagrant
![vault consul - phase 1](https://user-images.githubusercontent.com/9472095/47297619-7a535280-d60d-11e8-8804-e149170dd188.png)

## What does this PR do?

Demonstrate how two consul clusters can run on a single node where one is dedicated as a Vault Storage backend. 

## How was this PR implemented?

Run two instances of consul cluster one on the standard ports and the second on non standard ports.

## How long did it take?

30 minutes

